### PR TITLE
Allow external parties to reference defaultReporter

### DIFF
--- a/index.js
+++ b/index.js
@@ -107,3 +107,4 @@ module.exports = function(gulp, reporter) {
     });
 
 };
+module.exports.defaultReporter = defaultReporter;


### PR DESCRIPTION
This is done by exporting the default reporter as well.
This is especially useful if/when you would like the stats printed, as
well as done something else to.

I know I could just CP the code, but that also feels slightly weird :-)